### PR TITLE
Added cubeability to ActiveRecord objects

### DIFF
--- a/lib/ice/railtie.rb
+++ b/lib/ice/railtie.rb
@@ -1,5 +1,6 @@
 require 'active_model/serialization'
 require 'action_view'
+require 'active_record/base'
 
 module Ice
   class Railtie < Rails::Railtie
@@ -11,3 +12,5 @@ module Ice
 end
 
 ActiveModel::Serialization.send(:include, Ice::Cubeable)
+
+ActiveRecord::Base.send(:include, Ice::Cubeable)


### PR DESCRIPTION
I'm not sure why ActiveRecord objects wouldn't be cubeable by default.

Perhaps there's a change since Rails 3.1 that I'm not aware of? I'm on Rails 3.2, and ActiveModel::Serialization is not included in an ActiveRecord model by default.
